### PR TITLE
feat: Use dependency injection

### DIFF
--- a/carsharing.py
+++ b/carsharing.py
@@ -8,7 +8,7 @@ from typing import Annotated
 
 engine = create_engine("sqlite:///carsharing.db",
         connect_args={"check_same_thread":False}, # Needed for SQLite to work with multiple threads
-        echo=True,)
+        echo=True,) # Remove this in production
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/schemas.py
+++ b/schemas.py
@@ -16,7 +16,7 @@ class Trip(TripInput, table=True):
     id: int |None = Field(default=None, primary_key=True)
     car_id : int = Field(foreign_key="car.id")
 
-    car: "Car" = Relationship(back_populates="trips")
+    car: "Car" = Relationship(back_populates="trips") # Car is not implemented yet, so we use a string to avoid circular import issues
 
 class CarInput(SQLModel):
     size: str


### PR DESCRIPTION
## Description

This PR covers
- Implement the SQLModel (built on top of SQLAlchemy and Pydantic), inheriting from the Pydantic BaseModel class. Set the `table` argument to `True` to map to the database table.
- The connection string to SQLite db uses connect_string to support concurrent use of the DB.
- Add a generator function `get_session` that starts with a `with` block to create a session. Inside the block, it yields the session, which can be used as a dependency in FastAPI APIs. This session can be passed as an argument or annotated.
-  Implement the 1:many relationship to Car:Trip by using the Relationship object in SQLModel
